### PR TITLE
Add support for multiple managers in middleware

### DIFF
--- a/lib/warden/config.rb
+++ b/lib/warden/config.rb
@@ -32,7 +32,7 @@ module Warden
       end
     end
 
-    hash_accessor :failure_app, :default_scope, :intercept_401
+    hash_accessor :failure_app, :default_scope, :intercept_401, :namespace
 
     def initialize(other={})
       merge!(other)

--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -28,9 +28,9 @@ module Warden
     # If this is downstream from another warden instance, don't do anything.
     # :api: private
     def call(env) # :nodoc:
-      return @app.call(env) if env['warden'] && env['warden'].manager != self
+      return @app.call(env) if env[namespaced_name] && env[namespaced_name].manager != self
 
-      env['warden'] = Proxy.new(env, self)
+      env[namespaced_name] = Proxy.new(env, self)
       result = catch(:warden) do
         @app.call(env)
       end
@@ -91,7 +91,11 @@ module Warden
   private
 
     def intercept_401?(env)
-      config[:intercept_401] && !env['warden'].custom_failure?
+      config[:intercept_401] && !env[namespaced_name].custom_failure?
+    end
+
+    def namespaced_name
+      ['warden', config[:namespace]].compact.join('.')
     end
 
     # When a request is unauthenticated, here's where the processing occurs.
@@ -103,7 +107,7 @@ module Warden
         opts[:action] || 'unauthenticated'
       end
 
-      proxy  = env['warden']
+      proxy  = env[namespaced_name]
       result = options[:result] || proxy.result
 
       case result

--- a/spec/warden/config_spec.rb
+++ b/spec/warden/config_spec.rb
@@ -35,6 +35,12 @@ describe Warden::Config do
     @config.default_scope.should == :foo
   end
 
+  it "should set the namespace" do
+    @config.namespace.should == nil
+    @config.namespace = :foo
+    @config.namespace.should == :foo
+  end
+
   it "should merge given options on initialization" do
     Warden::Config.new(:foo => :bar)[:foo].should == :bar
   end

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -13,6 +13,12 @@ describe Warden::Manager do
     env["warden"].should be_an_instance_of(Warden::Proxy)
   end
 
+  it "should name the proxy accordingly to the specified namespace" do
+    env = env_with_params
+    setup_rack(success_app, :namespace => 'foobar').call(env)
+    env["warden.foobar"].should be_an_instance_of(Warden::Proxy)
+  end
+
   describe "thrown auth" do
     before(:each) do
       @basic_app = lambda{|env| [200,{'Content-Type' => 'text/plain'},'OK']}


### PR DESCRIPTION
I'm working on a gem for rails ([warden-github-rails](/fphilipe/warden-github-rails)) that inserts a warden middleware. Unfortunately, when the rails app already has a warden middleware (e.g. when using devise), the middleware downstream is ignored.

I'd like to propose and discuss a possibility to make multiple warden managers work.

Inside [`Warden::Manager#call`](https://github.com/hassox/warden/blob/master/lib/warden/manager.rb#L30) there is the check for an upstream manager:

```ruby
return @app.call(env) if env['warden'] && env['warden'].manager != self
```

I think an easy approach would be some kind of configuration merging such as:

```ruby
if env['warden'] && env['warden'].manager != self
  env['warden'].config.deep_merge!(config)
  return @app.call(env)
end
```

Would you guys think this would make sense at all?

Obviously the example above is a naïve approach. It might make sense to only copy over certain configs. One downside of simply merging is that it is not possible to have conditional assignments à la:

```ruby
# Upstream manager
config.failure_app = BadAuth

# Downstream manager
config.failure_app ||= lambda { |env| [401, {}, ['unauthorized']] }
```

Another thought I had was to allow all configs to be scoped, similarly to specifying `:strategies` per scope. This would allow a warden "plugin" to have a smaller footprint.

Any thoughts?

***

PS: See the [initial discussion](https://groups.google.com/forum/?fromgroups=#!topic/plataformatec-devise/ubEiaFSJwNc) with @josevalim at the devise email list.