### PR TITLE
scope should be a symbol

### DIFF
--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -162,6 +162,7 @@ module Warden
     #
     # :api: public
     def set_user(user, opts = {})
+      raise TypeError.new("scope must be a Symbol or String") if opts[:scope] && !(opts[:scope].is_a?(Symbol) || opts[:scope].is_a?(String))
       scope = (opts[:scope] ||= @config.default_scope)
 
       # Get the default options from the master configuration for the given scope

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -342,6 +342,14 @@ describe Warden::Proxy do
   end
 
   describe "set user" do
+    it "should raise an exception if the :scope option is not a symbol or string" do
+      app = lambda do |env|
+        env['warden'].authenticate(:pass, :scope => Object.new)
+      end
+
+      expect { setup_rack(app).call(@env) }.to raise_error
+    end
+
     it "should store the user into the session" do
       app = lambda do |env|
         env['warden'].authenticate(:pass)


### PR DESCRIPTION
I just spent an embarrassingly long amount of time of debugging something that eventually led to this fix:

``` diff
-      login_as(user, :scope => user)
+      login_as(user, :scope => :user)
```

I think it would be helpful if warden complained when anything but a symbol is passed in for the scope. 
