### PR TITLE
Fix: Handle Rack-middleware that return Rack::Response

### DIFF
--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -35,6 +35,7 @@ module Warden
         @app.call(env)
       end
 
+      result = result.instance_of?(Rack::Response) ? result.to_a : result
       result ||= {}
       case result
       when Array

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -323,4 +323,29 @@ describe Warden::Manager do
       end
     end
   end
+
+  describe "rack middleware of return value is Rack::Response (not an array)" do
+    before(:each) do
+      RAS = Warden::Strategies unless defined?(RAS)
+      Warden::Strategies.clear!
+      @app_rack_response = setup_rack do |env|
+        env['warden'].authenticate!(:foobar)
+        Rack::Response.new(["Foo Is A Winna"], 200, {"Content-Type" => "text/plain"})
+      end
+    end
+
+    describe "success" do
+      it "should pass through to the application when there is success" do
+        RAS.add(:foobar) do
+          def authenticate!
+            success!("A User")
+          end
+        end
+        env = env_with_params
+        result = @app_rack_response.call(env)
+        result[0].should be(200)
+        result[2].body.should eq(["Foo Is A Winna"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
In case of return Rack::Response (Not an Array) from other Rack-middleware even can handling.
(e.g. [Grape v0.12.0](https://github.com/intridea/grape/blob/master/UPGRADING.md#changes-in-middleware))
