### PR TITLE
Ready for Rack::Response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    warden (1.2.2)
+    warden (1.2.3)
       rack (>= 1.0)
 
 GEM
@@ -30,3 +30,6 @@ DEPENDENCIES
   rake
   rspec (~> 2)
   warden!
+
+BUNDLED WITH
+   1.10.6

--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -38,13 +38,11 @@ module Warden
       result ||= {}
       case result
       when Array
-        if result.first == 401 && intercept_401?(env)
-          process_unauthenticated(env)
-        else
-          result
-        end
+        handle_chain_result(result.first, result, env)
       when Hash
         process_unauthenticated(env, result)
+      when Rack::Response
+        handle_chain_result(result.status, result, env)
       end
     end
 
@@ -94,6 +92,14 @@ module Warden
     end
 
   private
+
+    def handle_chain_result(status, result, env)
+      if status == 401 && intercept_401?(env)
+        process_unauthenticated(env)
+      else
+        result
+      end
+    end
 
     def intercept_401?(env)
       config[:intercept_401] && !env['warden'].custom_failure?

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -142,7 +142,7 @@ describe Warden::Manager do
          action = nil
 
          failure = lambda do |_env|
-           action = _env['PATH_INFO'] 
+           action = _env['PATH_INFO']
            [401, {}, ['fail']]
          end
 
@@ -288,6 +288,20 @@ describe Warden::Manager do
         result[0].should be(523)
         result[1]["Custom-Header"].should eq("foo")
         result[2].should eq(["Custom Stuff"])
+      end
+    end
+
+    describe "app returns Rack::Response" do
+      it "should return it" do
+        RAS.add(:foobar) do
+          def authenticate!
+            custom!(Rack::Response.new(['body'], 201, {"Content-Type" => "text/plain"}))
+          end
+        end
+        result = @app.call(env_with_params)
+        result.status.should be(201)
+        result.body.should eq(['body'])
+        result.header['Content-Type'].should eq('text/plain')
       end
     end
 


### PR DESCRIPTION
Rack chain can return a `Rack::Response` additionally to `Array` and `Hash`. But warden is not ready for it and returns `nil` after the `call` evaluation. It causes bugs such as this [one](https://github.com/ruby-grape/grape/issues/1151#issuecomment-145292878).