### PR TITLE
Add mocked warden in test helpers

### DIFF
--- a/lib/warden/test/helpers.rb
+++ b/lib/warden/test/helpers.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'rack'
+
 module Warden
   module Test
     # A collection of test helpers for testing full stack rack applications using Warden
@@ -31,6 +33,61 @@ module Warden
           proxy.logout(*scopes)
         end
       end
+
+      # A helper method that provides the warden object by mocking the env variable.
+      # @api public
+      def warden
+        @warden ||= begin
+          env = env_with_params
+          setup_rack(success_app).call(env)
+          env['warden']
+        end
+      end
+
+      private
+
+      FAILURE_APP = lambda{|e|[401, {"Content-Type" => "text/plain"}, ["You Fail!"]] }
+
+      def env_with_params(path = "/", params = {}, env = {})
+        method = params.delete(:method) || "GET"
+        env = { 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => "#{method}" }.merge(env)
+        Rack::MockRequest.env_for("#{path}?#{Rack::Utils.build_query(params)}", env)
+      end
+
+      def setup_rack(app = nil, opts = {}, &block)
+        app ||= block if block_given?
+
+        opts[:failure_app]         ||= failure_app
+        opts[:default_strategies]  ||= [:password]
+        opts[:default_serializers] ||= [:session]
+        blk = opts[:configurator] || proc{}
+
+        Rack::Builder.new do
+          use opts[:session] || Warden::Test::Helpers::Session unless opts[:nil_session]
+          use Warden::Manager, opts, &blk
+          run app
+        end
+      end
+
+      def failure_app
+        Warden::Test::Helpers::FAILURE_APP
+      end
+
+      def success_app
+        lambda{|e| [200, {"Content-Type" => "text/plain"}, ["You Win"]]}
+      end
+
+      class Session
+        attr_accessor :app
+        def initialize(app,configs = {})
+          @app = app
+        end
+
+        def call(e)
+          e['rack.session'] ||= {}
+          @app.call(e)
+        end
+      end # session
     end
   end
 end

--- a/spec/warden/test/helpers_spec.rb
+++ b/spec/warden/test/helpers_spec.rb
@@ -85,6 +85,14 @@ describe Warden::Test::Helpers do
     expect($captures).to eq([:run])
   end
 
+  it "should return a valid mocked warden" do
+    user = "A User"
+    login_as user
+
+    expect(warden.class).to eq(Warden::Proxy)
+    expect(warden.user).to eq(user)
+  end
+
   describe "#asset_paths" do
     it "should default asset_paths to anything asset path regex" do
       expect(Warden.asset_paths).to eq([/^\/assets\//]      )


### PR DESCRIPTION
As discussed here: https://github.com/hassox/warden/issues/126

I need almost everything from Spec Helpers... we can work it out from here!

Also, the tests are failing with Rack version 1.3.0 but success with 1.6 +. You should consider to lock down all gems versions to a working one. That is why Travis is failing.