### PR TITLE
Fix strategy #redirect! when url string is frozen

### DIFF
--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -157,7 +157,7 @@ module Warden
       def redirect!(url, params = {}, opts = {})
         halt!
         @status = opts[:permanent] ? 301 : 302
-        headers["Location"] = url
+        headers["Location"] = url.dup
         headers["Location"] << "?" << Rack::Utils.build_query(params) unless params.empty?
         headers["Content-Type"] = opts[:content_type] || 'text/plain'
 


### PR DESCRIPTION
When working on a custom Devise login strategy I found that passing a frozen url throws a _'can't modify frozen string'_ error.

`redirect! Figaro.env.some_url`

 I fixed it by #dup'ing the string before calling:

`redirect! Figaro.env.some_url.dup`

but I think it's better to do this inside the library.
