### PR TITLE
Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+- 2.2
+- 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    warden (1.2.3)
+    warden (1.2.6)
       rack (>= 1.0)
 
 GEM
@@ -9,22 +9,22 @@ GEM
   specs:
     diff-lcs (1.2.5)
     rack (1.3.0)
-    rack-test (0.6.0)
+    rack-test (0.6.3)
       rack (>= 1.0)
-    rake (0.8.7)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -37,4 +37,4 @@ DEPENDENCIES
   warden!
 
 BUNDLED WITH
-   1.10.6
+   1.12.1

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,6 @@
+== Version 1.2.7 / 2016-10-12
+* Added 'frozen_string_literal' comment, bump ruby to 2.3
+
 == Version 1.2.6 / 2016-01-31
 * Separate test helpers to encapsulate Warden object mocking inside it's own class
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 require 'rubygems'
 require 'rake'
 $:.unshift  File.join(File.dirname(__FILE__), "lib")

--- a/lib/warden.rb
+++ b/lib/warden.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 require 'forwardable'
 

--- a/lib/warden/config.rb
+++ b/lib/warden/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 
 module Warden

--- a/lib/warden/errors.rb
+++ b/lib/warden/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Warden
   class Proxy

--- a/lib/warden/hooks.rb
+++ b/lib/warden/hooks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Warden
   module Hooks

--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 require 'warden/hooks'
 require 'warden/config'

--- a/lib/warden/mixins/common.rb
+++ b/lib/warden/mixins/common.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Warden
   module Mixins

--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 
 module Warden

--- a/lib/warden/session_serializer.rb
+++ b/lib/warden/session_serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Warden
   class SessionSerializer

--- a/lib/warden/strategies.rb
+++ b/lib/warden/strategies.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 module Warden
   module Strategies
     class << self

--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Warden
   module Strategies
@@ -157,7 +158,7 @@ module Warden
       def redirect!(url, params = {}, opts = {})
         halt!
         @status = opts[:permanent] ? 301 : 302
-        headers["Location"] = url
+        headers["Location"] = url.dup
         headers["Location"] << "?" << Rack::Utils.build_query(params) unless params.empty?
         headers["Content-Type"] = opts[:content_type] || 'text/plain'
 

--- a/lib/warden/test/helpers.rb
+++ b/lib/warden/test/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 
 module Warden

--- a/lib/warden/test/mock.rb
+++ b/lib/warden/test/mock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 
 require 'rack'

--- a/lib/warden/test/warden_helpers.rb
+++ b/lib/warden/test/warden_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 
 module Warden

--- a/lib/warden/version.rb
+++ b/lib/warden/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # encoding: utf-8
 module Warden
-  VERSION = "1.2.6".freeze
+  VERSION = "1.2.7"
 end

--- a/lib/warden/version.rb
+++ b/lib/warden/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Warden
   VERSION = "1.2.6".freeze

--- a/spec/helpers/request_helper.rb
+++ b/spec/helpers/request_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 module Warden::Spec
   module Helpers
     FAILURE_APP = lambda{|e|[401, {"Content-Type" => "text/plain"}, ["You Fail!"]] }

--- a/spec/helpers/strategies/fail_with_user.rb
+++ b/spec/helpers/strategies/fail_with_user.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:fail_with_user) do
   def authenticate!
     request.env['warden.spec.strategies'] ||= []

--- a/spec/helpers/strategies/failz.rb
+++ b/spec/helpers/strategies/failz.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:failz) do
   def authenticate!
     request.env['warden.spec.strategies'] ||= []

--- a/spec/helpers/strategies/invalid.rb
+++ b/spec/helpers/strategies/invalid.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:invalid) do
   def valid?
     false

--- a/spec/helpers/strategies/pass.rb
+++ b/spec/helpers/strategies/pass.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:pass) do
   def authenticate!
     request.env['warden.spec.strategies'] ||= []

--- a/spec/helpers/strategies/pass_with_message.rb
+++ b/spec/helpers/strategies/pass_with_message.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:pass_with_message) do
   def authenticate!
     request.env['warden.spec.strategies'] ||= []

--- a/spec/helpers/strategies/password.rb
+++ b/spec/helpers/strategies/password.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:password) do
   def authenticate!
     request.env['warden.spec.strategies'] ||= []

--- a/spec/helpers/strategies/single.rb
+++ b/spec/helpers/strategies/single.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 Warden::Strategies.add(:single) do
   def authenticate!
     request.env['warden.spec.strategies'] ||= []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 $TESTING=true
 
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')

--- a/spec/warden/authenticated_data_store_spec.rb
+++ b/spec/warden/authenticated_data_store_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe "authenticated data store" do

--- a/spec/warden/config_spec.rb
+++ b/spec/warden/config_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Config do

--- a/spec/warden/errors_spec.rb
+++ b/spec/warden/errors_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Proxy::Errors do

--- a/spec/warden/hooks_spec.rb
+++ b/spec/warden/hooks_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe "standard authentication hooks" do

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Manager do

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Proxy do

--- a/spec/warden/scoped_session_serializer.rb
+++ b/spec/warden/scoped_session_serializer.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Manager do

--- a/spec/warden/session_serializer_spec.rb
+++ b/spec/warden/session_serializer_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::SessionSerializer do

--- a/spec/warden/strategies/base_spec.rb
+++ b/spec/warden/strategies/base_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Strategies::Base do

--- a/spec/warden/strategies_spec.rb
+++ b/spec/warden/strategies_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Strategies do

--- a/spec/warden/test/helpers_spec.rb
+++ b/spec/warden/test/helpers_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Test::Helpers do

--- a/spec/warden/test/mock_spec.rb
+++ b/spec/warden/test/mock_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Test::Mock do

--- a/spec/warden/test/test_mode_spec.rb
+++ b/spec/warden/test/test_mode_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Warden::Test::WardenHelpers do

--- a/warden.gemspec
+++ b/warden.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 
 require './lib/warden/version'
 


### PR DESCRIPTION
@hassox can you take a look? We are using warden in a [project](https://github.com/zendesk/samson) that is on ruby 2.3 and it fails due to string mutation.
- Added `# frozen_string_literal: true` to files
- Fixed small issue in `Base#redirect!`
- Ran `bundle update` to fix failing tests
