### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
+install:
+  - bundle install
 rvm:
-- 2.2
-- 2.3
-- 2.4.1
+  - 2.2
+  - 2.3
+  - 2.4.1


### PR DESCRIPTION
Removes the `--deployment` on bundle command during TravisCI builds