### PR TITLE
Add test to verify action can be overridden

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'rack', '1.3'
+gem 'rack', '~> 2.0'
 
 group :test do
   gem 'rspec', '~>3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    rack (1.3.0)
+    rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
-    rake (12.0.0)
+    rake (12.1.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -30,11 +30,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rack (= 1.3)
+  rack (~> 2.0)
   rack-test
   rake
   rspec (~> 3)
   warden!
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.2

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -92,6 +92,18 @@ describe Warden::Manager do
         expect(env["warden.options"][:attempted_path]).to eq("/access/path")
       end
 
+      it "should set action in warden.options if overridden" do
+        env = env_with_params("/access/path", {})
+        app = lambda do |_env|
+          _env['warden'].authenticate(:pass)
+          throw(:warden, action: :different_action)
+        end
+        result = setup_rack(app, :failure_app => @fail_app).call(env)
+        expect(result.first).to eq(401)
+        expect(env["warden.options"][:action]).to eq(:different_action)
+      end
+
+
       it "should catch a resubmitted request" do
         # this is a bit convoluted. but it's occurred in the field with Rack::OpenID
         $count = 0


### PR DESCRIPTION
## Background

@Quintasan reported in #151 that `:action` parameters were not making it through to the failure application. This added a spec to explicitly test this.