### PR TITLE
Avoid session options mutation

### DIFF
--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -172,7 +172,13 @@ module Warden
 
       if opts[:store] != false && opts[:event] != :fetch
         options = env[ENV_SESSION_OPTIONS]
-        options[:renew] = true if options
+        if options
+          if options.frozen?
+            env[ENV_SESSION_OPTIONS] = options.merge(:renew => true).freeze
+          else
+            options[:renew] = true
+          end
+        end
         session_serializer.store(user, scope)
       end
 

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -409,6 +409,36 @@ RSpec.describe Warden::Proxy do
       end
       setup_rack(app).call(@env)
     end
+
+    it "should set renew on rack.session.options" do
+      app = lambda do |env|
+        env['warden'].authenticate(:pass)
+        valid_response
+      end
+
+      @env[Warden::Proxy::ENV_SESSION_OPTIONS] = {}
+
+      setup_rack(app).call(@env)
+
+      expect(@env[Warden::Proxy::ENV_SESSION_OPTIONS]).to include(renew: true)
+      expect(@env[Warden::Proxy::ENV_SESSION_OPTIONS]).to_not be_frozen
+    end
+
+    it "should not modify attempt to modify a frozen rack.session.options" do
+      app = lambda do |env|
+        env['warden'].authenticate(:pass)
+        valid_response
+      end
+
+      original_options = {}.freeze
+      @env[Warden::Proxy::ENV_SESSION_OPTIONS] = original_options
+
+      setup_rack(app).call(@env)
+
+      expect(original_options).to be_empty
+      expect(@env[Warden::Proxy::ENV_SESSION_OPTIONS]).to include(renew: true)
+      expect(@env[Warden::Proxy::ENV_SESSION_OPTIONS]).to be_frozen
+    end
   end
 
   describe "lock" do

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -413,21 +413,25 @@ RSpec.describe Warden::Proxy do
 
   describe "lock" do
     it "should not run any strategy" do
-      _app = lambda do |env|
+      app = lambda do |env|
         env['warden'].lock!
         env['warden'].authenticate(:pass)
         expect(env['warden'].user).to be_nil
         valid_response
       end
+
+      setup_rack(app).call(@env)
     end
 
     it "should keep already authenticated users" do
-      _app = lambda do |env|
+      app = lambda do |env|
         env['warden'].authenticate(:pass)
         env['warden'].lock!
         expect(env['warden'].user).not_to be_nil
         valid_response
       end
+
+      setup_rack(app).call(@env)
     end
   end
 


### PR DESCRIPTION
This PR changes the `Proxy#set_user` method to avoid attempting to modify a frozen `env['rack.session.options']`.

The change to freeze `Rack:Session::Abstract::Persisted::DEFAULT_OPTIONS` happened in https://github.com/rack/rack/pull/1110, which appeared in `rack` 2.0.2.

Fixes #147 