### PR TITLE
Make it able to throw in Warden::Manager.on_request

### DIFF
--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -32,6 +32,7 @@ module Warden
 
       env['warden'] = Proxy.new(env, self)
       result = catch(:warden) do
+        env['warden'].on_request
         @app.call(env)
       end
 

--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -29,6 +29,11 @@ module Warden
       @env, @users, @winning_strategies, @locked = env, {}, {}, false
       @manager, @config = manager, manager.config.dup
       @strategies = Hash.new { |h,k| h[k] = {} }
+    end
+
+    # Run the on_request callbacks
+    # :api: private
+    def on_request
       manager._run_callbacks(:on_request, self)
     end
 

--- a/lib/warden/test/mock.rb
+++ b/lib/warden/test/mock.rb
@@ -37,7 +37,7 @@ module Warden
       def app
         @app ||= begin
           opts = {
-            failure_app: lambda {
+            failure_app: lambda { |_e|
               [401, { 'Content-Type' => 'text/plain' }, ['You Fail!']]
             },
             default_strategies: :password,

--- a/spec/warden/hooks_spec.rb
+++ b/spec/warden/hooks_spec.rb
@@ -368,5 +368,22 @@ RSpec.describe "standard authentication hooks" do
       setup_rack(app).call(env)
       expect(env['warden.spec.order']).to eq([1,2,3])
     end
+
+    it "should have the proxy on env in on_request" do
+      warden = nil
+      RAM.on_request{|proxy| warden = proxy.env['warden']}
+      app = lambda{|e| valid_response}
+      env = env_with_params
+      setup_rack(app).call(env)
+      expect(warden).to eq(env['warden'])
+    end
+
+    it "should be able to throw in on_request" do
+      RAM.on_request{|proxy| throw :warden}
+      app = lambda{|e| valid_response}
+      env = env_with_params
+      result = setup_rack(app).call(env)
+      expect(result.first).to eq(401)
+    end
   end
 end


### PR DESCRIPTION
In `Warden::Test::Helpers#login_as`, it's using
`Warden.on_next_request`, which is using
`Warden::Manager.on_request`, and it would call
`proxy.set_user` which would possibly throw.

This means before this patch, `Proxy.new` could
throw in the tests. We're also expecting `env['warden']`
to be set in `Warden::Manager`, therefore we need to
decouple initializing the object and calling the `on_request`
callbacks, and move `env['warden'].on_request` inside the
`catch` block to handle the logging in process properly
in the tests.

I am not sure if people are relying on this behaviour
other than tests, but I assume it's not bad to be able to
`throw` in `Warden::Manager.on_request` as a way to
stop the chain early.

Without this patch, in the tests, `:warden` would be thrown
whenever it failed to login. People might be depending on
this behaviour, but throwing symbols like this could break
people's cleanup code.

Here's an example: https://github.com/rails/rails/pull/28373

Rails was using `rescue Exception` before to cleanup stuffs,
but it would not be rescuing any symbols. There were other
codes doing things like this, causing some weird transient
test failures like this for GitLab:
https://gitlab.com/gitlab-org/gitlab-ce/issues/40093

In short, we shouldn't let any `throw` bubble up. The other
way to fix this would be not using `Warden::Manager.on_request`
to login, but that might need more changes and could break
even more codes. Also, I think it's not bad to be able to
`throw :warden` in `Warden::Manager.on_request`.

/cc @Reprazent